### PR TITLE
Allow gson's @SerializeName to be used

### DIFF
--- a/auto-parcel-gson-processor/src/main/java/auto/parcelgson/processor/AutoParcelProcessor.java
+++ b/auto-parcel-gson-processor/src/main/java/auto/parcelgson/processor/AutoParcelProcessor.java
@@ -78,6 +78,7 @@ public class AutoParcelProcessor extends AbstractProcessor {
       .put("@auto.parcelgson.gson.annotations.Expose", "@com.google.gson.annotations.Expose")
       .put("@auto.parcelgson.gson.annotations.JsonAdapter", "@com.google.gson.annotations.JsonAdapter")
       .put("@auto.parcelgson.gson.annotations.SerializedName", "@com.google.gson.annotations.SerializedName")
+      .put("@com.google.gson.annotations.SerializedName", "@com.google.gson.annotations.SerializedName")
       .put("@auto.parcelgson.gson.annotations.Since", "@com.google.gson.annotations.Since")
       .put("@auto.parcelgson.gson.annotations.Until", "@com.google.gson.annotations.Until")
       .build();

--- a/auto-parcel-gson-processor/src/test/java/auto/parcelgson/processor/GsonCopyAnnotationTest.java
+++ b/auto-parcel-gson-processor/src/test/java/auto/parcelgson/processor/GsonCopyAnnotationTest.java
@@ -241,6 +241,13 @@ public class GsonCopyAnnotationTest extends TestCase {
         ImmutableList.of("@com.google.gson.annotations.SerializedName(value=\"foo\")"));
   }
 
+  public void testGsonSerializeNameAnnotation() {
+    assertGeneratedMatchesForField(
+        ImmutableList.of("import com.google.gson.annotations.SerializedName;"),
+        ImmutableList.of("@SerializedName(\"foo\")"),
+        ImmutableList.of("@com.google.gson.annotations.SerializedName(value=\"foo\")"));
+  }
+
   public void testJsonAdapterAnnotation() {
     assertGeneratedMatchesForField(
         ImmutableList.of("import auto.parcelgson.gson.annotations.JsonAdapter;"),

--- a/auto-parcel-gson/build.gradle
+++ b/auto-parcel-gson/build.gradle
@@ -5,7 +5,7 @@ targetCompatibility = '1.6'
 sourceCompatibility = '1.6'
 
 dependencies {
-    compile 'com.google.code.gson:gson:2.3.1'
+    compile 'com.google.code.gson:gson:2.4'
 }
 
 tasks.withType(Test) {

--- a/auto-parcel-gson/src/main/java/auto/parcelgson/gson/annotations/SerializedName.java
+++ b/auto-parcel-gson/src/main/java/auto/parcelgson/gson/annotations/SerializedName.java
@@ -59,12 +59,15 @@ import java.lang.annotation.Target;
  * <p>NOTE: The value you specify in this annotation must be a valid JSON field name.</p>
  *
  * @see com.google.gson.FieldNamingPolicy
+ * @deprecated Gson's {@link com.google.gson.annotations.SerializedName} now supports annotating methods. Use that one
+ * instead.
  *
  * @author Inderjeet Singh
  * @author Joel Leitch
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.METHOD)
+@Deprecated
 public @interface SerializedName {
 
   /**


### PR DESCRIPTION
In gson 2.4 they added support for putting @SerializeName on methods.
Update to copy over that one on to the generated class's fields as
well as this lib's version.  In order to prevent confusion, this lib's
version is also deprecated and may be removed in the future.
